### PR TITLE
Make the rotary encoder more responsive

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -163,25 +163,27 @@ static bool encoder_update(uint8_t index, uint8_t state) {
     index += thisHand;
 #endif
     encoder_pulses[i] += encoder_LUT[state & 0xF];
-    if (encoder_pulses[i] >= resolution) {
-        encoder_value[index]++;
-        changed = true;
-#ifdef ENCODER_MAP_ENABLE
-        encoder_exec_mapping(index, ENCODER_COUNTER_CLOCKWISE);
-#else  // ENCODER_MAP_ENABLE
-        encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
-#endif // ENCODER_MAP_ENABLE
+    if ( ((state & 0xF) == 0xF) || (encoder_pulses[i] >= resolution) || (encoder_pulses[i] <= -resolution) ) {
+        if (encoder_pulses[i] >= 1) {
+            encoder_value[index]++;
+            changed = true;
+    #ifdef ENCODER_MAP_ENABLE
+            encoder_exec_mapping(index, ENCODER_COUNTER_CLOCKWISE);
+    #else  // ENCODER_MAP_ENABLE
+            encoder_update_kb(index, ENCODER_COUNTER_CLOCKWISE);
+    #endif // ENCODER_MAP_ENABLE
+        }
+        if (encoder_pulses[i] <= -1) { // direction is arbitrary here, but this clockwise
+            encoder_value[index]--;
+            changed = true;
+    #ifdef ENCODER_MAP_ENABLE
+            encoder_exec_mapping(index, ENCODER_CLOCKWISE);
+    #else  // ENCODER_MAP_ENABLE
+            encoder_update_kb(index, ENCODER_CLOCKWISE);
+    #endif // ENCODER_MAP_ENABLE
+        }
+        encoder_pulses[i] = 0;
     }
-    if (encoder_pulses[i] <= -resolution) { // direction is arbitrary here, but this clockwise
-        encoder_value[index]--;
-        changed = true;
-#ifdef ENCODER_MAP_ENABLE
-        encoder_exec_mapping(index, ENCODER_CLOCKWISE);
-#else  // ENCODER_MAP_ENABLE
-        encoder_update_kb(index, ENCODER_CLOCKWISE);
-#endif // ENCODER_MAP_ENABLE
-    }
-    encoder_pulses[i] %= resolution;
 #ifdef ENCODER_DEFAULT_POS
     if ((state & 0x3) == ENCODER_DEFAULT_POS) {
         encoder_pulses[i] = 0;


### PR DESCRIPTION
The resolution 4 rotary encoder on my Keychron Q2 is missing a lot of ticks, when not all 4 pulses are detected. By putting a constraint on the default state 0xF of the encoder it is possible to catch a lot of these lost ticks and the performance of the rotary encoder improves noticeable and is reliable.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Modified _encoder_update_ to be more permissive about lost pulses when returning to the default state 0xF (no movement) to detect if a tick has happened. E.g. on resolution 4 rotary encoder all ticks with only 1, 2 or 3 detected pulses have been discarded in the original code, but when the rotary encoder returns to the recognized state of no movement and pulses are present, we can be sure, that a tick has happened. This PR catches all these lost ticks with only 1,2 or 3 pulses, which results in a more reliable performance of the rotary encoder.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x ] Core
- [ ] Bugfix
- [ ] New feature
- [x ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
